### PR TITLE
Remove `-lstdc++fs` from the default link flags

### DIFF
--- a/src/dds/toolchain/from_dds.cpp
+++ b/src/dds/toolchain/from_dds.cpp
@@ -570,15 +570,7 @@ toolchain dds::parse_toolchain_dds(const lm::pair_list& pairs, strv context) {
         string_seq ret;
         if (is_msvc) {
             ret = {get_compiler(language::cxx), "/nologo", "/EHsc", "<IN>", "/Fe<OUT>"};
-        } else if (is_gnu) {
-            ret = {get_compiler(language::cxx),
-                   "-fPIC",
-                   "-fdiagnostics-color",
-                   "<IN>",
-                   "-pthread",
-                   "-lstdc++fs",
-                   "-o<OUT>"};
-        } else if (is_clang) {
+        } else if (is_gnu_like) {
             ret = {get_compiler(language::cxx),
                    "-fPIC",
                    "-fdiagnostics-color",

--- a/src/dds/toolchain/from_dds.test.cpp
+++ b/src/dds/toolchain/from_dds.test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Generating toolchain commands") {
         "g++ -fPIC -fdiagnostics-color -pthread -Wall -Wextra -Wpedantic -Wconversion "
         "-MD -MF foo.o.d -MT foo.o -c foo.cpp -ofoo.o",
         "ar rcs stuff.a foo.o bar.o",
-        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -lstdc++fs -omeow.exe");
+        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -omeow.exe");
 
     check_tc_compile(
         "Compiler-ID: GNU\nDebug: True",
@@ -58,7 +58,7 @@ TEST_CASE("Generating toolchain commands") {
         "g++ -g -fPIC -fdiagnostics-color -pthread -Wall -Wextra -Wpedantic -Wconversion "
         "-MD -MF foo.o.d -MT foo.o -c foo.cpp -ofoo.o",
         "ar rcs stuff.a foo.o bar.o",
-        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -lstdc++fs -omeow.exe -g");
+        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -omeow.exe -g");
 
     check_tc_compile(
         "Compiler-ID: GNU\nDebug: True\nOptimize: True",
@@ -67,7 +67,7 @@ TEST_CASE("Generating toolchain commands") {
         "g++ -O2 -g -fPIC -fdiagnostics-color -pthread -Wall -Wextra -Wpedantic -Wconversion "
         "-MD -MF foo.o.d -MT foo.o -c foo.cpp -ofoo.o",
         "ar rcs stuff.a foo.o bar.o",
-        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -lstdc++fs -omeow.exe -O2 -g");
+        "g++ -fPIC -fdiagnostics-color foo.o bar.a -pthread -omeow.exe -O2 -g");
 
     check_tc_compile("Compiler-ID: MSVC",
                      "cl.exe /MT /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",


### PR DESCRIPTION
Close #12 