### PR TITLE
Fix small typo in the documentation

### DIFF
--- a/docs/guide/toolchains.rst
+++ b/docs/guide/toolchains.rst
@@ -52,7 +52,7 @@ For convenience, ``dds`` includes several built-in toolchains that can be
 accessed in the ``--toolchain`` command-line option using a colon ``:``
 prefix::
 
-    $ dds build -T :gcc
+    $ dds build -t :gcc
 
 ``dds`` will treat the leading colon (``:``) as a name for a built-in
 toolchain (this means that a toolchain's filepath may not begin with a colon).


### PR DESCRIPTION
Hi,

This PR fixes a small typo in the toolchain documentation, the shortcut for the `--toolchain` flag should be lowercase.

PS: Thank you so, so much for this project, it's a game changer!