### PR TITLE
added option to disable /showIncludes to toolchain.json

### DIFF
--- a/src/dds/toolchain/from_json.cpp
+++ b/src/dds/toolchain/from_json.cpp
@@ -84,6 +84,8 @@ toolchain dds::parse_toolchain_json_data(const json5::data& dat, std::string_vie
     opt_string_seq create_archive;
     opt_string_seq link_executable;
     opt_string_seq tty_flags;
+    
+    optional<bool> hide_includes;
 
     // For copy-pasting convenience: ‘{}’
 
@@ -201,6 +203,10 @@ toolchain dds::parse_toolchain_json_data(const json5::data& dat, std::string_vie
                             std::terminate();
                         },
                     },
+                },
+                if_key{"hide_includes",
+                    require_type<bool>("`hide_includes` must be a bool"),
+                    put_into{hide_includes}
                 },
                 [&](auto key, auto &&) -> dc_reject_t {
                     // They've given an unknown key. Ouch.
@@ -708,6 +714,12 @@ toolchain dds::parse_toolchain_json_data(const json5::data& dat, std::string_vie
         } else {
             assert(false && "Impossible compiler_id while deducing `tty_flags`");
             std::terminate();
+        }
+    });
+
+    tc.hide_includes = read_opt(hide_includes,[&]() -> bool {
+        if(is_msvc) {
+            return false;
         }
     });
 

--- a/src/dds/toolchain/prep.hpp
+++ b/src/dds/toolchain/prep.hpp
@@ -29,6 +29,7 @@ struct toolchain_prep {
     std::string exe_suffix;
 
     enum file_deps_mode deps_mode;
+    bool hide_includes = false;
 
     toolchain realize() const;
 };

--- a/src/dds/toolchain/toolchain.cpp
+++ b/src/dds/toolchain/toolchain.cpp
@@ -40,6 +40,7 @@ toolchain toolchain::realize(const toolchain_prep& prep) {
     ret._exe_suffix          = prep.exe_suffix;
     ret._deps_mode           = prep.deps_mode;
     ret._tty_flags           = prep.tty_flags;
+    ret._hide_includes       = prep.hide_includes;
     return ret;
 }
 
@@ -145,7 +146,7 @@ compile_command_info toolchain::create_compile_command(const compile_file_spec& 
                 std::string_view(gnu_depfile_path->string()),
                 "-MQ"sv,
                 std::string_view(spec.out_path.string())});
-    } else if (_deps_mode == file_deps_mode::msvc) {
+    } else if (_deps_mode == file_deps_mode::msvc && !_hide_includes) {
         flags.push_back("/showIncludes");
     }
 

--- a/src/dds/toolchain/toolchain.hpp
+++ b/src/dds/toolchain/toolchain.hpp
@@ -62,6 +62,7 @@ class toolchain {
     string_seq _link_exe;
     string_seq _warning_flags;
     string_seq _tty_flags;
+    
 
     std::string _archive_prefix;
     std::string _archive_suffix;
@@ -71,7 +72,7 @@ class toolchain {
     std::string _exe_suffix;
 
     enum file_deps_mode _deps_mode;
-
+    bool _hide_includes;
 public:
     toolchain() = default;
 


### PR DESCRIPTION
`/showIncludes` can be extremely noisy and makes it hard to figure out what the actual issue with the code is, this PR adds an option to disable `showIncludes` in the toolchain file by specifiying ` hide_includes: true `