### PR TITLE
Improve custom compile & link flags

### DIFF
--- a/docs/guide/toolchains.rst
+++ b/docs/guide/toolchains.rst
@@ -430,12 +430,12 @@ Defaults::
 
     {
         // On GNU-like compilers (GCC, Clang):
-        c_compile_file:   "<compiler> <base_compile_flags> [flags] -c [in] -o[out]",
-        cxx_compile_file: "<compiler> <base_compile_flags> [flags] -c [in] -o[out]",
+        c_compile_file:   "<compiler> <base_flags> [flags] -c [in] -o[out]",
+        cxx_compile_file: "<compiler> <base_flags> [flags] -c [in] -o[out]",
 
         // On MSVC:
-        c_compile_file:   "cl.exe <base_compile_flags> [flags] /c [in] /Fo[out]",
-        cxx_compile_file: "cl.exe <base_compile_flags> [flags] /c [in] /Fo[out]",
+        c_compile_file:   "cl.exe <base_flags> [flags] /c [in] /Fo[out]",
+        cxx_compile_file: "cl.exe <base_flags> [flags] /c [in] /Fo[out]",
     }
 
 
@@ -546,19 +546,31 @@ compiler, the resulting command line will contain ``-Wall -Wextra -Wpedantic
 -Wconversion -Werror``.
 
 
-.. _toolchains.opts.base_compile_flags:
+.. _toolchains.opts.base_flags:
 
-``base_compile_flags``
+``base_flags``, ``base_c_flags``, and ``base_cxx_flags``
 ----------------------
 
-When you compile your project, ``dds`` will concatenate the flags from this
-option with the flags provided by ``flags``. This option is "advanced," because
-it provides a set of defaults based on the ``compiler_id``.
+When you compile your project, ``dds`` uses a set of default flags appropriate
+to the target language and compiler. These flags are always included in the
+compile command and are inserted in addition to those flags provided by
+``flags``, ``c_flags``, and ``cxx_flags``.
 
 On GNU-like compilers, the base flags are ``-fPIC -pthread``. On
 MSVC the default flags are ``/EHsc /nologo /permissive-`` for C++ and ``/nologo
 /permissive-`` for C.
 
-For example, if you set ``flags`` to ``-fno-exceptions`` on a GNU-like
-compiler, the resulting command line will contain ``-fPIC -pthread
--fno-exceptions``.
+These defaults may be changed by providing values for three different options.
+The ``base_flags`` value is always output, regardless of language. Flags
+exclusive to C are specified in ``base_c_flags``, and those exclusively for
+C++ should be in ``base_cxx_flags``. Note that the language-specific values are
+independent from ``base_flags``; that is, providing ``base_c_flags`` or
+``base_cxx_flags`` does not override or prevent the inclusion of the
+``base_flags`` value, and vice-versa. Empty values are acceptable, should you
+need to simply prohibit one or more of the defaults from being used.
+
+For example, if you set ``flags`` to ``-ansi`` on a GNU-like compiler, the
+resulting command line will contain ``-fPIC -pthread -ansi``. If, additionally,
+you set ``base_flags`` to ``-fno-builtin`` and ``base_cxx_flags`` to
+``-fno-exceptions``, the generated command will include ``-fno-builtin
+-fno-exceptions -ansi`` for C++ and ``-fno-builtin -ansi`` for C.

--- a/docs/guide/toolchains.rst
+++ b/docs/guide/toolchains.rst
@@ -430,12 +430,12 @@ Defaults::
 
     {
         // On GNU-like compilers (GCC, Clang):
-        c_compile_file:   "<compiler> -fPIC -pthread [flags] -c [in] -o[out]",
-        cxx_compile_file: "<compiler> -fPIC -pthread [flags] -c [in] -o[out]",
+        c_compile_file:   "<compiler> <base_compile_flags> [flags] -c [in] -o[out]",
+        cxx_compile_file: "<compiler> <base_compile_flags> [flags] -c [in] -o[out]",
 
         // On MSVC:
-        c_compile_file:   "cl.exe /nologo /permissive- [flags] /c [in] /Fo[out]",
-        cxx_compile_file: "cl.exe /EHsc /nologo /permissive- [flags] /c [in] /Fo[out]",
+        c_compile_file:   "cl.exe <base_compile_flags> [flags] /c [in] /Fo[out]",
+        cxx_compile_file: "cl.exe <base_compile_flags> [flags] /c [in] /Fo[out]",
     }
 
 
@@ -544,3 +544,21 @@ On GNU-like compilers, the base warning flags are ``-Wall -Wextra -Wpedantic
 For example, if you set ``warning_flags`` to ``"-Werror"`` on a GNU-like
 compiler, the resulting command line will contain ``-Wall -Wextra -Wpedantic
 -Wconversion -Werror``.
+
+
+.. _toolchains.opts.base_compile_flags:
+
+``base_compile_flags``
+----------------------
+
+When you compile your project, ``dds`` will concatenate the flags from this
+option with the flags provided by ``flags``. This option is "advanced," because
+it provides a set of defaults based on the ``compiler_id``.
+
+On GNU-like compilers, the base flags are ``-fPIC -pthread``. On
+MSVC the default flags are ``/EHsc /nologo /permissive-`` for C++ and ``/nologo
+/permissive-`` for C.
+
+For example, if you set ``flags`` to ``-fno-exceptions`` on a GNU-like
+compiler, the resulting command line will contain ``-fPIC -pthread
+-fno-exceptions``.

--- a/res/toolchain-schema.json
+++ b/res/toolchain-schema.json
@@ -164,6 +164,10 @@
                     "description": "Set the base warning flags for the toolchain. These are always prepended to `warning_flags`.",
                     "$ref": "#/definitions/command_line_flags"
                 },
+                "base_compile_flags": {
+                    "description": "Set the base compile flags for the toolchain. These are always prepended to `flags`.",
+                    "$ref": "#/definitions/command_line_flags"
+                },
                 "c_compile_file": {
                     "description": "Set the command template for compiling C source files",
                     "$ref": "#/definitions/command_line_flags"

--- a/res/toolchain-schema.json
+++ b/res/toolchain-schema.json
@@ -164,8 +164,16 @@
                     "description": "Set the base warning flags for the toolchain. These are always prepended to `warning_flags`.",
                     "$ref": "#/definitions/command_line_flags"
                 },
-                "base_compile_flags": {
+                "base_flags": {
                     "description": "Set the base compile flags for the toolchain. These are always prepended to `flags`.",
+                    "$ref": "#/definitions/command_line_flags"
+                },
+                "base_c_flags": {
+                    "description": "Set the base C compile flags for the toolchain. These are always prepended to `flags`.",
+                    "$ref": "#/definitions/command_line_flags"
+                },
+                "base_cxx_flags": {
+                    "description": "Set the base C++ compile flags for the toolchain. These are always prepended to `flags`.",
                     "$ref": "#/definitions/command_line_flags"
                 },
                 "c_compile_file": {

--- a/src/dds/toolchain/from_json.cpp
+++ b/src/dds/toolchain/from_json.cpp
@@ -703,9 +703,9 @@ toolchain dds::parse_toolchain_json_data(const json5::data& dat, std::string_vie
             assert(false && "No link-exe command");
             std::terminate();
         }
-        extend(ret, get_link_flags());
         return ret;
     });
+    extend(tc.link_exe, get_link_flags());
 
     tc.tty_flags = read_opt(tty_flags, [&]() -> string_seq {
         if (!compiler_id) {

--- a/src/dds/toolchain/from_json.test.cpp
+++ b/src/dds/toolchain/from_json.test.cpp
@@ -86,11 +86,21 @@ TEST_CASE("Generating toolchain commands") {
         "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
 
     check_tc_compile(
-        "{compiler_id: 'gnu', flags: '-fno-rtti', advanced: {base_compile_flags: "
+        "{compiler_id: 'gnu', flags: '-fno-rtti', advanced: {base_flags: "
         "'-fno-exceptions'}}",
         "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fno-rtti -fno-exceptions",
         "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
         "-fno-rtti -fno-exceptions",
+        "ar rcs stuff.a foo.o bar.o",
+        "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
+
+    check_tc_compile(
+        "{compiler_id: 'gnu', flags: '-ansi', cxx_flags: '-fno-rtti', advanced: {base_flags: "
+        "'-fno-builtin', base_cxx_flags: '-fno-exceptions'}}",
+        "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -ansi -fno-rtti -fno-builtin "
+        "-fno-exceptions",
+        "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
+        "-ansi -fno-rtti -fno-builtin -fno-exceptions",
         "ar rcs stuff.a foo.o bar.o",
         "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
 
@@ -111,57 +121,63 @@ TEST_CASE("Generating toolchain commands") {
         "g++ foo.o bar.a -omeow.exe -mthumb");
 
     check_tc_compile("{compiler_id: 'msvc'}",
-                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",
-                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT /nologo /permissive- /EHsc",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT /nologo /permissive- /EHsc",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MT");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: true}",
-        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
-        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /nologo /permissive- /EHsc",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /nologo /permissive- /EHsc",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Z7");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: 'embedded'}",
-        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
-        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /nologo /permissive- /EHsc",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /nologo /permissive- /EHsc",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Z7");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: 'split'}",
-        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /EHsc /nologo /permissive-",
-        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /EHsc /nologo /permissive-",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /nologo /permissive- /EHsc",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /nologo /permissive- /EHsc",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Zi /FS");
 
     check_tc_compile(
         "{compiler_id: 'msvc', flags: '-DFOO'}",
-        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /EHsc /nologo /permissive-",
-        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /EHsc /nologo /permissive-",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /nologo /permissive- /EHsc",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /nologo /permissive- /EHsc",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MT");
 
     check_tc_compile("{compiler_id: 'msvc', runtime: {static: false}}",
-                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MD /EHsc /nologo /permissive-",
-                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MD /EHsc /nologo /permissive-",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MD /nologo /permissive- /EHsc",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MD /nologo /permissive- /EHsc",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MD");
 
     check_tc_compile(
         "{compiler_id: 'msvc', runtime: {static: false}, debug: true}",
-        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /EHsc /nologo /permissive-",
-        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /nologo /permissive- /EHsc",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /nologo /permissive- /EHsc",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MDd /Z7");
 
     check_tc_compile("{compiler_id: 'msvc', runtime: {static: false, debug: true}}",
-                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /EHsc /nologo /permissive-",
-                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /EHsc /nologo /permissive-",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /nologo /permissive- /EHsc",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /nologo /permissive- /EHsc",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MDd");
+
+    check_tc_compile("{compiler_id: 'msvc', advanced: {base_cxx_flags: ''}}",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT /nologo /permissive-",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT /nologo /permissive-",
+                     "lib /nologo /OUT:stuff.a foo.o bar.o",
+                     "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MT");
 }
 
 TEST_CASE("Manipulate a toolchain and file compilation") {

--- a/src/dds/toolchain/from_json.test.cpp
+++ b/src/dds/toolchain/from_json.test.cpp
@@ -48,85 +48,102 @@ void check_tc_compile(std::string_view tc_content,
 
 TEST_CASE("Generating toolchain commands") {
     check_tc_compile("{compiler_id: 'gnu'}",
-                     "g++ -fPIC -pthread -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
-                     "g++ -fPIC -pthread -Wall -Wextra -Wpedantic -Wconversion "
-                     "-MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
+                     "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fPIC -pthread",
+                     "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c "
+                     "foo.cpp -ofoo.o -fPIC -pthread",
                      "ar rcs stuff.a foo.o bar.o",
                      "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
 
     check_tc_compile("{compiler_id: 'gnu', debug: true}",
-                     "g++ -g -fPIC -pthread -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
-                     "g++ -g -fPIC -pthread -Wall -Wextra -Wpedantic -Wconversion "
-                     "-MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
+                     "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -g -fPIC -pthread",
+                     "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c "
+                     "foo.cpp -ofoo.o -g -fPIC -pthread",
                      "ar rcs stuff.a foo.o bar.o",
                      "g++ -fPIC foo.o bar.a -pthread -omeow.exe -g");
 
     check_tc_compile("{compiler_id: 'gnu', debug: true, optimize: true}",
-                     "g++ -O2 -g -fPIC -pthread -MD -MF foo.o.d -MQ foo.o -c foo.cpp "
-                     "-ofoo.o",
-                     "g++ -O2 -g -fPIC -pthread -Wall -Wextra -Wpedantic -Wconversion "
-                     "-MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
+                     "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -O2 -g -fPIC -pthread",
+                     "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c "
+                     "foo.cpp -ofoo.o -O2 -g -fPIC -pthread",
                      "ar rcs stuff.a foo.o bar.o",
                      "g++ -fPIC foo.o bar.a -pthread -omeow.exe -O2 -g");
 
     check_tc_compile(
         "{compiler_id: 'gnu', debug: 'split', optimize: true}",
-        "g++ -O2 -g -gsplit-dwarf -fPIC -pthread -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
-        "g++ -O2 -g -gsplit-dwarf -fPIC -pthread -Wall -Wextra -Wpedantic -Wconversion -MD -MF "
-        "foo.o.d -MQ foo.o -c foo.cpp -ofoo.o",
+        "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -O2 -g -gsplit-dwarf -fPIC -pthread",
+        "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
+        "-O2 -g -gsplit-dwarf -fPIC -pthread",
         "ar rcs stuff.a foo.o bar.o",
         "g++ -fPIC foo.o bar.a -pthread -omeow.exe -O2 -g -gsplit-dwarf");
 
+    check_tc_compile(
+        "{compiler_id: 'gnu', flags: '-fno-rtti', advanced: {cxx_compile_file: 'g++ [flags] -c "
+        "[in] -o[out]'}}",
+        "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fno-rtti -fPIC -pthread",
+        "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
+        "-fno-rtti -fPIC -pthread",
+        "ar rcs stuff.a foo.o bar.o",
+        "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
+
+    check_tc_compile(
+        "{compiler_id: 'gnu', flags: '-fno-rtti', advanced: {base_compile_flags: "
+        "'-fno-exceptions'}}",
+        "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fno-rtti -fno-exceptions",
+        "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
+        "-fno-rtti -fno-exceptions",
+        "ar rcs stuff.a foo.o bar.o",
+        "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
+
     check_tc_compile("{compiler_id: 'msvc'}",
-                     "cl.exe /MT /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-                     "cl.exe /MT /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MT");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: true}",
-        "cl.exe /MTd /Z7 /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-        "cl.exe /MTd /Z7 /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Z7");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: 'embedded'}",
-        "cl.exe /MTd /Z7 /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-        "cl.exe /MTd /Z7 /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Z7 /EHsc /nologo /permissive-",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Z7");
 
     check_tc_compile(
         "{compiler_id: 'msvc', debug: 'split'}",
-        "cl.exe /MTd /Zi /FS /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-        "cl.exe /MTd /Zi /FS /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /EHsc /nologo /permissive-",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MTd /Zi /FS /EHsc /nologo /permissive-",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MTd /Zi /FS");
 
     check_tc_compile(
         "{compiler_id: 'msvc', flags: '-DFOO'}",
-        "cl.exe /MT /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o -DFOO",
-        "cl.exe /MT /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o -DFOO",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /EHsc /nologo /permissive-",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT -DFOO /EHsc /nologo /permissive-",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MT");
 
     check_tc_compile("{compiler_id: 'msvc', runtime: {static: false}}",
-                     "cl.exe /MD /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-                     "cl.exe /MD /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MD /EHsc /nologo /permissive-",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MD /EHsc /nologo /permissive-",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MD");
 
     check_tc_compile(
         "{compiler_id: 'msvc', runtime: {static: false}, debug: true}",
-        "cl.exe /MDd /Z7 /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-        "cl.exe /MDd /Z7 /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+        "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /EHsc /nologo /permissive-",
+        "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /Z7 /EHsc /nologo /permissive-",
         "lib /nologo /OUT:stuff.a foo.o bar.o",
         "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MDd /Z7");
 
     check_tc_compile("{compiler_id: 'msvc', runtime: {static: false, debug: true}}",
-                     "cl.exe /MDd /EHsc /nologo /permissive- /showIncludes /c foo.cpp /Fofoo.o",
-                     "cl.exe /MDd /EHsc /nologo /permissive- /W4 /showIncludes /c foo.cpp /Fofoo.o",
+                     "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MDd /EHsc /nologo /permissive-",
+                     "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MDd /EHsc /nologo /permissive-",
                      "lib /nologo /OUT:stuff.a foo.o bar.o",
                      "cl.exe /nologo /EHsc foo.o bar.a /Femeow.exe /MDd");
 }
@@ -140,8 +157,6 @@ TEST_CASE("Manipulate a toolchain and file compilation") {
     auto cmd = tc.create_compile_command(cfs, dds::fs::current_path(), dds::toolchain_knobs{});
     CHECK(cmd.command
           == std::vector<std::string>{"g++",
-                                      "-fPIC",
-                                      "-pthread",
                                       "-MD",
                                       "-MF",
                                       "foo.o.d",
@@ -149,7 +164,9 @@ TEST_CASE("Manipulate a toolchain and file compilation") {
                                       "foo.o",
                                       "-c",
                                       "foo.cpp",
-                                      "-ofoo.o"});
+                                      "-ofoo.o",
+                                      "-fPIC",
+                                      "-pthread"});
 
     cfs.definitions.push_back("FOO=BAR");
     cmd = tc.create_compile_command(cfs,
@@ -157,8 +174,6 @@ TEST_CASE("Manipulate a toolchain and file compilation") {
                                     dds::toolchain_knobs{.is_tty = true});
     CHECK(cmd.command
           == std::vector<std::string>{"g++",
-                                      "-fPIC",
-                                      "-pthread",
                                       "-fdiagnostics-color",
                                       "-D",
                                       "FOO=BAR",
@@ -169,14 +184,14 @@ TEST_CASE("Manipulate a toolchain and file compilation") {
                                       "foo.o",
                                       "-c",
                                       "foo.cpp",
-                                      "-ofoo.o"});
+                                      "-ofoo.o",
+                                      "-fPIC",
+                                      "-pthread"});
 
     cfs.include_dirs.push_back("fake-dir");
     cmd = tc.create_compile_command(cfs, dds::fs::current_path(), dds::toolchain_knobs{});
     CHECK(cmd.command
           == std::vector<std::string>{"g++",
-                                      "-fPIC",
-                                      "-pthread",
                                       "-I",
                                       "fake-dir",
                                       "-D",
@@ -188,5 +203,7 @@ TEST_CASE("Manipulate a toolchain and file compilation") {
                                       "foo.o",
                                       "-c",
                                       "foo.cpp",
-                                      "-ofoo.o"});
+                                      "-ofoo.o",
+                                      "-fPIC",
+                                      "-pthread"});
 }

--- a/src/dds/toolchain/from_json.test.cpp
+++ b/src/dds/toolchain/from_json.test.cpp
@@ -94,6 +94,22 @@ TEST_CASE("Generating toolchain commands") {
         "ar rcs stuff.a foo.o bar.o",
         "g++ -fPIC foo.o bar.a -pthread -omeow.exe");
 
+    check_tc_compile("{compiler_id: 'gnu', link_flags: '-mthumb'}",
+                     "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fPIC -pthread",
+                     "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c "
+                     "foo.cpp -ofoo.o -fPIC -pthread",
+                     "ar rcs stuff.a foo.o bar.o",
+                     "g++ -fPIC foo.o bar.a -pthread -omeow.exe -mthumb");
+
+    check_tc_compile(
+        "{compiler_id: 'gnu', link_flags: '-mthumb', advanced: {link_executable: 'g++ [in] "
+        "-o[out]'}}",
+        "g++ -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o -fPIC -pthread",
+        "g++ -Wall -Wextra -Wpedantic -Wconversion -MD -MF foo.o.d -MQ foo.o -c foo.cpp -ofoo.o "
+        "-fPIC -pthread",
+        "ar rcs stuff.a foo.o bar.o",
+        "g++ foo.o bar.a -omeow.exe -mthumb");
+
     check_tc_compile("{compiler_id: 'msvc'}",
                      "cl.exe /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",
                      "cl.exe /W4 /showIncludes /c foo.cpp /Fofoo.o /MT /EHsc /nologo /permissive-",


### PR DESCRIPTION
(I'd consider these changes to both fix a bug and adjust behavior, so I've used elements from both issue templates.)

**Describe the bug**
I encountered several issues with compile & link flags used with `c_compile_file` / `cxx_compile_file` / `link_executable`.

The original issue I encountered was that `flags` values were not included in the output compile command string when a custom `c_compile_file` or `cxx_compile_file` was specified. The [docs](https://dds.pizza/docs/guide/toolchains.html#c-compile-file-and-cxx-compile-file) state that `[flags]` is a required placeholder in the `*_compile_file` templates. My expectation was not only that any `flags` specified would be included, but also those flags determined from other toolchain options (e.g. `optimize` or `runtime.static`). Neither of those expectations were met.

The subsequent issue experienced, similar to the first, is that `link_flags` are not included in the command string if a custom `link_executable` template is specified.

**Existing Behavior and Potential Problems**
Ultimately, my reason for specifying ``c_compile_file``, ``cxx_compile_file``, and ``link_executable`` was to avoid the default ``-fPIC -pthread`` flags from being used. Given the design of the toolchain and the current options, I found it odd that there was no way to remove/change the ``-fPIC -pthread`` flags _unless a different command template is provided_. Rather than force users to muck around w/ such an advanced option, I thought providing a ``base_compile_flags`` option - similar in spirit and functionality to ``base_warning_flags`` - would be a good route.

Unfortunately, the design of ``toolchain`` and spec parsing was not amenable to the solution I had hoped/expected to implement. In [``create_compile_command``](https://github.com/vector-of-bool/dds/blob/350e08650716fc2ab0e9426a8ec7fe1522467ce5/src/dds/toolchain/toolchain.cpp#L75), where the ``[[flags]]`` arg in the templates is [replaced](https://github.com/vector-of-bool/dds/blob/350e08650716fc2ab0e9426a8ec7fe1522467ce5/src/dds/toolchain/toolchain.cpp#L155), the value of the inserted ``flags`` does not actually include the value specified in the toolchain spec ``flags``. Rather, it contains any relevant flags for TTY, cache busting, includes, etc. The ``toolchain_prep`` used to [realize](https://github.com/vector-of-bool/dds/blob/350e08650716fc2ab0e9426a8ec7fe1522467ce5/src/dds/toolchain/toolchain.cpp#L25) the ``toolchain`` does not even store the configured ``flags``. It is in the [JSON parsing and construction](https://github.com/vector-of-bool/dds/blob/350e08650716fc2ab0e9426a8ec7fe1522467ce5/src/dds/toolchain/from_json.cpp#L556) of the ``toolchain_prep`` that the ``flags`` value is inserted into the command.

As such, my approach was to alter ``parse_toolchain_json_data`` to 1) fix ``flags`` inclusion in any compile template; 2) allow changing the defaults via ``base_compile_flags``. I think adjusting the ``toolchain`` code would be a better overall solution, but I didn't want to dig in too much and make too many changes without consultation. (Frankly, I just needed it to work to build my packages correctly.) My changes as-is had the side-effect that all user-specified ``flags`` will be appended at the end (hence so many test cases needed updating); probably only a cosmetic difference but maybe an issue on MS compilers as I am unable to test those.

**Steps to Reproduce**

1. Create a ``toolchain.json5`` file with contents: `` {compiler_id: 'gnu', flags: '-fno-rtti', advanced: {c_compile_file: 'g++ [flags] -c [in] -o[out]'}}``
2. ``dds build -t /path/to/toolchain.json5``

**`dds` Output**
```
g++ -c foo.cpp -ofoo.cpp.o -fdiagnostics-color -I include -I src -MD -MF foo.o.d -MQ foo.o
```

**Desktop (please complete the following information):**
 - Operating System: macOS, linux
 - Compiler: GCC, Clang
 - `dds` Version: `0.1.0-alpha.6` / 350e08650716fc2ab0e9426a8ec7fe1522467ce5

