### PR TITLE
Better mac paths

### DIFF
--- a/src/dds/util/paths.macos.cpp
+++ b/src/dds/util/paths.macos.cpp
@@ -21,6 +21,6 @@ fs::path dds::user_home_dir() {
 
 fs::path dds::user_data_dir() { return user_home_dir() / "Library/Application Support"; }
 fs::path dds::user_cache_dir() { return user_home_dir() / "Library/Caches"; }
-fs::path dds::user_config_dir() { return user_home_dir() / "Preferences"; }
+fs::path dds::user_config_dir() { return user_home_dir() / "Library/Preferences"; }
 
 #endif

--- a/src/dds/util/paths.macos.cpp
+++ b/src/dds/util/paths.macos.cpp
@@ -19,8 +19,29 @@ fs::path dds::user_home_dir() {
     return ret;
 }
 
-fs::path dds::user_data_dir() { return user_home_dir() / "Library/Application Support"; }
-fs::path dds::user_cache_dir() { return user_home_dir() / "Library/Caches"; }
-fs::path dds::user_config_dir() { return user_home_dir() / "Library/Preferences"; }
+fs::path dds::user_data_dir() {
+    static auto ret = []() -> fs::path {
+        return fs::absolute(dds::getenv("XDG_DATA_HOME", [] {
+            return user_home_dir() / "Library/Application Support";
+        }));
+    }();
+    return ret;
+}
+
+fs::path dds::user_cache_dir() {
+    static auto ret = []() -> fs::path {
+        return fs::absolute(
+            dds::getenv("XDG_CACHE_HOME", [] { return user_home_dir() / "Library/Caches"; }));
+    }();
+    return ret;
+}
+
+fs::path dds::user_config_dir() {
+    static auto ret = []() -> fs::path {
+        return fs::absolute(
+            dds::getenv("XDG_CONFIG_HOME", [] { return user_home_dir() / "Library/Preferences"; }));
+    }();
+    return ret;
+}
 
 #endif


### PR DESCRIPTION
**Existing Behavior and Potential Problems**

On macOS, `dds` currently searches `~/Preferences` for a default toolchain. This path does not exist and should instead be `~/Library/Preferences`.

Additionally, there is no way to control or customize the macOS search paths `dds` uses as there is for Linux. Given that macOS is Unix-like and many folks (like me) also use the XDG directory structure, it seems desirable that the macOS path determination mimic that of Linux.

**Describe Alternatives**

Potentially provide other environment variables to override the default paths, but that would mean `dds`-specific variables and doesn't seem to match the spirit of `dds`: [uniformity and simplicity](https://dds.pizza/docs/design.html).

If a user has `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, and/or `$XDG_CACHE_HOME`, then `dds` will "just work" with those paths using these small changes.

Tested on macOS Catalina and Big Sur.
