### PR TITLE
[BUG] Reject multiple standards in builtin toolchain

### DIFF
--- a/src/dds/toolchain/toolchain.test.cpp
+++ b/src/dds/toolchain/toolchain.test.cpp
@@ -1,0 +1,8 @@
+#include <dds/toolchain/toolchain.hpp>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("Builtin toolchains reject multiple standards") {
+    const std::optional<dds::toolchain> parsed = dds::toolchain::get_builtin("c++11:c++14:gcc");
+    CHECK_FALSE(parsed.has_value());
+}


### PR DESCRIPTION
Fixes #65 .

Again, this isn't super important, but I figured if I already almost gave a working patch in the issue, I might as well submit a PR.