### PR TITLE
Update dev docs

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -6,7 +6,7 @@ are controlled via Python scripts. You will need Python 3.6 or later available
 on your system to get started.
 
 
-.. _Poetry: python-poetry.org
+.. _Poetry: https://python-poetry.org
 
 Getting Started with *Poetry*
 *****************************
@@ -88,4 +88,3 @@ Code JSON build task that builds ``dds`` and also contains the environment
 variables required for the MSVC toolchain to compile and link programs. You can
 save this JSON task into ``.vscode/tasks.json`` to use as your primary build
 task while hacking on ``dds``.
-

--- a/docs/dev/reqs.rst
+++ b/docs/dev/reqs.rst
@@ -17,6 +17,8 @@ Building ``dds`` has a simple set of requirements:
   including Concepts. Newer releases of Visual C++ that ship with **VS
   2019** will be sufficient on Windows, as will **GCC 9** with ``-fconcepts`` on
   other platforms.
+- On Linux, the OpenSSL headers are needed. This can be installed through the
+  ``libssl-dev`` APT package.
 
 .. note::
     On Windows, you will need to execute the build from within a Visual C++
@@ -26,4 +28,3 @@ Building ``dds`` has a simple set of requirements:
 .. note::
     At the time of writing, C++20 Concepts has not yet been released in Clang,
     but should be available in LLVM/Clang 11 and newer.
-


### PR DESCRIPTION
 - Link to Poetry rather than an accidental relative link.
 - Mention the requirement of `libssl-dev`.

Fixes #63 and #64 .