### PR TITLE
Fix name collisions in objects from libs/

### DIFF
--- a/src/dds/build/plan/library.cpp
+++ b/src/dds/build/plan/library.cpp
@@ -31,7 +31,7 @@ std::optional<fs::path> library_plan::generated_include_dir() const noexcept {
 library_plan library_plan::create(const library_root&             lib,
                                   const library_build_params&     params,
                                   std::optional<std::string_view> qual_name_) {
-    const fs::path out_dir = params.out_subdir / lib.path_from_root();
+    const fs::path out_dir = params.out_subdir / lib.path_namespace();
 
     // Source files are kept in three groups:
     std::vector<source_file> app_sources;

--- a/src/dds/build/plan/library.cpp
+++ b/src/dds/build/plan/library.cpp
@@ -106,7 +106,10 @@ library_plan library_plan::create(const library_root&             lib,
     auto lib_compile_files =  //
         lib_sources           //
         | ranges::views::transform([&](const source_file& sf) {
-              return compile_file_plan(compile_rules, sf, qual_name, params.out_subdir / "obj");
+              return compile_file_plan(compile_rules,
+                                       sf,
+                                       qual_name,
+                                       params.out_subdir / lib.path_from_root() / "obj");
           })
         | ranges::to_vector;
 

--- a/src/dds/sdist/library/root.cpp
+++ b/src/dds/sdist/library/root.cpp
@@ -56,7 +56,7 @@ auto collect_pf_sources(path_ref path) {
 
 }  // namespace
 
-library_root library_root::from_directory(path_ref lib_dir, path_ref path_from_root) {
+library_root library_root::from_directory(path_ref lib_dir, path_ref path_namespace) {
     assert(lib_dir.is_absolute());
     auto sources = collect_pf_sources(lib_dir);
 
@@ -73,7 +73,7 @@ library_root library_root::from_directory(path_ref lib_dir, path_ref path_from_r
         }
     }
 
-    auto lib = library_root(lib_dir, path_from_root, std::move(sources), std::move(man));
+    auto lib = library_root(lib_dir, path_namespace, std::move(sources), std::move(man));
 
     return lib;
 }

--- a/src/dds/sdist/library/root.hpp
+++ b/src/dds/sdist/library/root.hpp
@@ -18,8 +18,9 @@ namespace dds {
 class library_root {
     // The path containing the source directories for this library
     fs::path _path;
-    // The path to this library root from the project root; used for namespacing object files.
-    fs::path _path_from_root;
+    // The path to this library root from the project root; used for namespacing outputs (object
+    // files, test executables, etc.).
+    fs::path _path_namespace;
     // The sources that are part of this library
     source_list _sources;
     // The library manifest associated with this library (may be generated)
@@ -27,9 +28,9 @@ class library_root {
 
     // Private constructor. Use named constructor `from_directory`, which will build
     // the construct arguments approperiately
-    library_root(path_ref dir, path_ref path_from_root, source_list&& src, library_manifest&& man)
+    library_root(path_ref dir, path_ref path_namespace, source_list&& src, library_manifest&& man)
         : _path(dir)
-        , _path_from_root(path_from_root)
+        , _path_namespace(path_namespace)
         , _sources(std::move(src))
         , _man(std::move(man)) {}
 
@@ -39,7 +40,7 @@ public:
      * directory path. This will load the sources and manifest properly and
      * return the resulting library object.
      */
-    static library_root from_directory(path_ref lib_dir, path_ref path_from_root);
+    static library_root from_directory(path_ref lib_dir, path_ref path_namespace);
 
     /**
      * Obtain the manifest for this library
@@ -64,7 +65,7 @@ public:
     /**
      * The path to this library from the project root.
      */
-    path_ref path_from_root() const noexcept { return _path_from_root; }
+    path_ref path_namespace() const noexcept { return _path_namespace; }
 
     /**
      * The directory that should be considered the "public" include directory.

--- a/src/dds/sdist/library/root.hpp
+++ b/src/dds/sdist/library/root.hpp
@@ -18,6 +18,8 @@ namespace dds {
 class library_root {
     // The path containing the source directories for this library
     fs::path _path;
+    // The path to this library root from the project root; used for namespacing object files.
+    fs::path _path_from_root;
     // The sources that are part of this library
     source_list _sources;
     // The library manifest associated with this library (may be generated)
@@ -25,8 +27,9 @@ class library_root {
 
     // Private constructor. Use named constructor `from_directory`, which will build
     // the construct arguments approperiately
-    library_root(path_ref dir, source_list&& src, library_manifest&& man)
+    library_root(path_ref dir, path_ref path_from_root, source_list&& src, library_manifest&& man)
         : _path(dir)
+        , _path_from_root(path_from_root)
         , _sources(std::move(src))
         , _man(std::move(man)) {}
 
@@ -36,7 +39,7 @@ public:
      * directory path. This will load the sources and manifest properly and
      * return the resulting library object.
      */
-    static library_root from_directory(path_ref);
+    static library_root from_directory(path_ref lib_dir, path_ref path_from_root);
 
     /**
      * Obtain the manifest for this library
@@ -57,6 +60,11 @@ public:
      * The root path for this library (parent of `src/` and `include/`, if present)
      */
     path_ref path() const noexcept { return _path; }
+
+    /**
+     * The path to this library from the project root.
+     */
+    path_ref path_from_root() const noexcept { return _path_from_root; }
 
     /**
      * The directory that should be considered the "public" include directory.

--- a/tests/colliding_libs_objects/proj-exec/libs/hello/src/hello.test.cpp
+++ b/tests/colliding_libs_objects/proj-exec/libs/hello/src/hello.test.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;  // Success!
+}

--- a/tests/colliding_libs_objects/proj-exec/libs/hello2/src/hello.test.cpp
+++ b/tests/colliding_libs_objects/proj-exec/libs/hello2/src/hello.test.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 1;  // Failure
+}

--- a/tests/colliding_libs_objects/proj/libs/hello/src/hello.cpp
+++ b/tests/colliding_libs_objects/proj/libs/hello/src/hello.cpp
@@ -1,0 +1,5 @@
+#include <string>
+
+namespace hello {
+std::string message() { return "Hello 1"; }
+}  // namespace hello

--- a/tests/colliding_libs_objects/proj/libs/hello/src/hello.test.cpp
+++ b/tests/colliding_libs_objects/proj/libs/hello/src/hello.test.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <string>
+
+namespace hello {
+std::string message();
+}
+
+int main() {
+    auto msg = hello::message();
+    std::cout << msg << '\n';
+    if (msg != "Hello 1")
+        return 1;
+}

--- a/tests/colliding_libs_objects/proj/libs/hello2/src/hello.cpp
+++ b/tests/colliding_libs_objects/proj/libs/hello2/src/hello.cpp
@@ -1,0 +1,5 @@
+#include <string>
+
+namespace hello {
+std::string message() { return "Hello 2"; }
+}  // namespace hello

--- a/tests/colliding_libs_objects/proj/libs/hello2/src/hello2.test.cpp
+++ b/tests/colliding_libs_objects/proj/libs/hello2/src/hello2.test.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <string>
+
+namespace hello {
+std::string message();
+}
+
+int main() {
+    auto msg = hello::message();
+    std::cout << msg << '\n';
+    if (msg != "Hello 2")
+        return 1;
+}

--- a/tests/colliding_libs_objects/test_colliding_libs_objects.py
+++ b/tests/colliding_libs_objects/test_colliding_libs_objects.py
@@ -1,6 +1,14 @@
 from dds_ci.testing import ProjectOpener
+from dds_ci.testing.error import expect_error_marker
 
 
 def test_compile_libs_with_colliding_object_files(project_opener: ProjectOpener) -> None:
     proj = project_opener.open('proj')
     proj.build()
+
+
+def test_compile_libs_with_colliding_test_executables(project_opener: ProjectOpener) -> None:
+    proj = project_opener.open('proj-exec')
+    with expect_error_marker('build-failed-test-failed'):
+        # Use only a single process to make the failure consistent
+        proj.build(jobs=1)

--- a/tests/colliding_libs_objects/test_colliding_libs_objects.py
+++ b/tests/colliding_libs_objects/test_colliding_libs_objects.py
@@ -1,0 +1,6 @@
+from dds_ci.testing import ProjectOpener
+
+
+def test_compile_libs_with_colliding_object_files(project_opener: ProjectOpener) -> None:
+    proj = project_opener.open('proj')
+    proj.build()

--- a/tools/dds_ci/testing/fixtures.py
+++ b/tools/dds_ci/testing/fixtures.py
@@ -90,6 +90,7 @@ class Project:
               *,
               toolchain: Optional[Pathish] = None,
               fixup_toolchain: bool = True,
+              jobs: Optional[int] = None,
               timeout: Optional[int] = None,
               tweaks_dir: Optional[Path] = None) -> None:
         """
@@ -102,6 +103,7 @@ class Project:
             self.dds.build(root=self.root,
                            build_root=self.build_root,
                            toolchain=toolchain,
+                           jobs=jobs,
                            timeout=timeout,
                            tweaks_dir=tweaks_dir,
                            more_args=['-ltrace'])

--- a/tools/get-win-openssl.ps1
+++ b/tools/get-win-openssl.ps1
@@ -12,8 +12,8 @@ New-Item -ItemType Container $build_dir -ErrorAction Ignore
 $local_tgz = Join-Path $build_dir "openssl.tgz"
 
 # This is the path to the release static vs2019 x64 build of OpenSSL in bintray
-$conan_ssl_path = "_/openssl/1.1.1h/_/7098aea4e4f2247cc9b5dcaaa1ebddbe/package/a79a557254fabcb77849dd623fed97c9c5ab7651/141ef2c6711a254707ba1f7f4fd07ad4"
-$openssl_url = "https://dl.bintray.com/conan/conan-center/$conan_ssl_path/conan_package.tgz"
+$conan_ssl_path = "_/openssl/1.1.1h/_/8aee28bb7f844aa2e8e9f2b9e988027e/package/a79a557254fabcb77849dd623fed97c9c5ab7651/c200a0954463ed55a55d99809c0dba96"
+$openssl_url = "https://center.conan.io/artifactory/api/conan/conan-center/v1/files/$conan_ssl_path/conan_package.tgz"
 
 Write-Host "Downloading OpenSSL for Windows"
 Invoke-WebRequest `

--- a/tools/get-win-openssl.ps1
+++ b/tools/get-win-openssl.ps1
@@ -9,16 +9,7 @@ $root_dir = Split-Path -Parent $tools_dir
 $build_dir = Join-Path $root_dir "_build"
 New-Item -ItemType Container $build_dir -ErrorAction Ignore
 
-$local_tgz = Join-Path $build_dir "openssl.tgz"
-
-# This is the path to the release static vs2019 x64 build of OpenSSL in bintray
-$conan_ssl_path = "_/openssl/1.1.1h/_/8aee28bb7f844aa2e8e9f2b9e988027e/package/a79a557254fabcb77849dd623fed97c9c5ab7651/c200a0954463ed55a55d99809c0dba96"
-$openssl_url = "https://center.conan.io/artifactory/api/conan/conan-center/v1/files/$conan_ssl_path/conan_package.tgz"
-
-Write-Host "Downloading OpenSSL for Windows"
-Invoke-WebRequest `
-    -Uri $openssl_url `
-    -OutFile $local_tgz
+$local_tgz = Join-Path $tools_dir "windows-openssl.tgz"
 
 $openssl_tree = Join-Path $root_dir "external/OpenSSL"
 Write-Host "Expanding OpenSSL archive..."


### PR DESCRIPTION
Fixes #71 

Apparently I got most of the way implementing this a while ago. Solves the issue by including the path from root in the output files of library roots under libs/. In a non-libs/ layout, the output paths should be unaffected.