### PR TITLE
Filter randen_benchmarks.cc from abseil library

### DIFF
--- a/tools/gen-catalog-json.py
+++ b/tools/gen-catalog-json.py
@@ -568,7 +568,7 @@ PACKAGES = [
                                     '**/*_test.c*',
                                     '**/*_testing.c*',
                                     '**/*_benchmark.c*',
-                                    '**/benchmarks.c*',
+                                    '**/*benchmarks.c*',
                                     '**/*_test_common.c*',
                                     '**/mocking_*.c*',
                                     # Misc files that should be removed:


### PR DESCRIPTION
Hopefully this is the right way to change this - I'm not 100% sure!
The abseil library on repo-1.dds.pizza contains a file `randen_benchmarks.cc` ([here](https://github.com/abseil/abseil-cpp/blob/master/absl/random/internal/randen_benchmarks.cc)) which has a `main()` function defined. It looks like similar files have been filtered via the set of globs but this one manages to evade deletion.
Looking through the file it creates no non-static symbols other than the main function so removal should be safe.

I've also cloned the abseil repo and checked that this new glob isn't overly aggressive, the only extra match is the above file. I've run the `gen-catalog-json.py` and the output seems sane, I'm not really sure what uses it after that to test further though

Sorry for the trivial PR - I noticed odd behaviour when building an executable linking to abseil!