### PR TITLE
Fix --if-exists help message

### DIFF
--- a/extras/bash-completion/dds.completion.bash
+++ b/extras/bash-completion/dds.completion.bash
@@ -288,7 +288,7 @@ _dds_complete_pkg_create()
   FLAGS=(
     [--project]='directory'
     [--out]=' '
-    [--if-exists]='replace skip fail'
+    [--if-exists]='replace ignore fail'
   )
   POSITIONAL=()
 
@@ -321,7 +321,7 @@ _dds_complete_pkg_import()
   SUBCOMMANDS=()
   FLAGS=(
     [--stdin]=''
-    [--if-exists]='replace skip fail'
+    [--if-exists]='replace ignore fail'
   )
   POSITIONAL=(
     'repeat:file' # <path-or-url> ...
@@ -435,7 +435,7 @@ _dds_complete_repoman_init()
 
   SUBCOMMANDS=()
   FLAGS=(
-    [--if-exists]='replace skip fail'
+    [--if-exists]='replace ignore fail'
     [--name]=' '
   )
   POSITIONAL=(
@@ -485,7 +485,7 @@ _dds_complete_repoman_import()
   declare -A SUBCOMMANDS FLAGS
   SUBCOMMANDS=()
   FLAGS=(
-    [--if-exists]="replace skip fail"
+    [--if-exists]="replace ignore fail"
   )
   POSITIONAL=(
     'directory' # <repo-dir>

--- a/src/dds/cli/options.cpp
+++ b/src/dds/cli/options.cpp
@@ -26,7 +26,7 @@ struct setup {
     argument if_exists_arg{
         .long_spellings = {"if-exists"},
         .help           = "What to do if the resource already exists",
-        .valname        = "{replace,skip,fail}",
+        .valname        = "{replace,ignore,fail}",
         .action         = put_into(opts.if_exists),
     };
 


### PR DESCRIPTION
Despite the help message saying that --if-exists expects its value to be {replace,skip,fail}, "skip" is an invalid setting; it actually expects "ignore". This updates the help message to match the current behavior.

Additionally, these incorrect values were used in the bash completion, so the "skip"s there were also updated to "ignore"s.

Fixes #91.