### PR TITLE
Fix pkg create --if-exists=ignore

### DIFF
--- a/src/dds/cli/cmd/pkg_create.cpp
+++ b/src/dds/cli/cmd/pkg_create.cpp
@@ -7,6 +7,7 @@
 #include <boost/leaf/handle_exception.hpp>
 #include <fansi/styled.hpp>
 #include <fmt/core.h>
+#include <neo/assert.hpp>
 
 using namespace fansi::literals;
 
@@ -27,7 +28,7 @@ int pkg_create(const options& opts) {
             auto filepath         = opts.out_path.value_or(fs::current_path() / default_filename);
             create_sdist_targz(filepath, params);
             dds_log(info,
-                    "Created source dirtribution archive: .bold.cyan[{}]"_styled,
+                    "Created source distribution archive: .bold.cyan[{}]"_styled,
                     filepath.string());
             return 0;
         },
@@ -49,6 +50,22 @@ int pkg_create(const options& opts) {
                     ec.message());
             write_error_marker("failed-package-json5-scan");
             return 1;
+        },
+        [&](boost::leaf::catch_<user_error<errc::sdist_exists>> exc) -> int {
+            if (opts.if_exists == if_exists::ignore) {
+                // Satisfy the 'ignore' semantics by returning a success exit code, but still warn
+                // the user to let them know what happened.
+                dds_log(warn, "{}", exc.value().what());
+                return 0;
+            }
+            // If if_exists::replace, we wouldn't be here (not an error). Thus, since it's not
+            // if_exists::ignore, it must be if_exists::fail here.
+            neo_assert_always(invariant,
+                              opts.if_exists == if_exists::fail,
+                              "Unhandled value for if_exists");
+
+            // rethrow; the default handling works.
+            throw;
         });
 }
 

--- a/src/dds/cli/cmd/pkg_create.cpp
+++ b/src/dds/cli/cmd/pkg_create.cpp
@@ -64,6 +64,7 @@ int pkg_create(const options& opts) {
                               opts.if_exists == if_exists::fail,
                               "Unhandled value for if_exists");
 
+            write_error_marker("sdist-already-exists");
             // rethrow; the default handling works.
             throw;
         });

--- a/src/dds/cli/options.cpp
+++ b/src/dds/cli/options.cpp
@@ -294,7 +294,7 @@ struct setup {
             = "Path to the project for which to create a source distribution.\n"
               "Default is the current working directory.";
         pkg_create_cmd.add_argument(out_arg.dup()).help
-            = "Destination path for the source distributioon archive";
+            = "Destination path for the source distribution archive";
         pkg_create_cmd.add_argument(if_exists_arg.dup()).help
             = "What to do if the destination names an existing file";
     }

--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -25,6 +25,31 @@ def test_create_pkg(test_project: Project, tmp_path: Path) -> None:
     assert dest.is_file(), 'Did not create an sdist in the new location'
 
 
+def test_create_pkg_already_exists_fails(test_project: Project) -> None:
+    test_project.pkg_create()
+    with error.expect_error_marker('sdist-already-exists'):
+        test_project.pkg_create()
+
+
+def test_create_pkg_already_exists_fails_with_explicit_fail(test_project: Project) -> None:
+    test_project.pkg_create()
+    with error.expect_error_marker('sdist-already-exists'):
+        test_project.pkg_create(if_exists='fail')
+
+
+def test_create_pkg_already_exists_succeeds_with_ignore(test_project: Project) -> None:
+    test_project.pkg_create()
+    test_project.pkg_create(if_exists='ignore')
+
+
+def test_create_pkg_already_exists_succeeds_with_replace(test_project: Project) -> None:
+    sd_path: Path = test_project.build_root / 'foo@1.2.3.tar.gz'
+    test_project.build_root.mkdir(exist_ok=True, parents=True)
+    sd_path.touch()
+    test_project.pkg_create(if_exists='replace')
+    assert sd_path.stat().st_size > 0, 'Did not replace the existing file'
+
+
 @pytest.fixture()
 def _test_pkg(test_project: Project) -> Tuple[Path, Project]:
     repo_content_path = test_project.dds.repo_dir / 'foo@1.2.3'

--- a/tools/dds_ci/testing/fixtures.py
+++ b/tools/dds_ci/testing/fixtures.py
@@ -156,13 +156,14 @@ class Project:
         with tc_mod.fixup_toolchain(toolchain or tc_mod.get_default_test_toolchain()) as tc:
             self.dds.compile_file(paths, toolchain=tc, out=self.build_root, project_dir=self.root)
 
-    def pkg_create(self, *, dest: Optional[Pathish] = None) -> None:
+    def pkg_create(self, *, dest: Optional[Pathish] = None, if_exists: Optional[str] = None) -> None:
         self.build_root.mkdir(exist_ok=True, parents=True)
         self.dds.run([
             'pkg',
             'create',
             self.project_dir_arg,
             f'--out={dest}' if dest else (),
+            f'--if-exists={if_exists}' if if_exists else (),
         ], cwd=self.build_root)
 
     def sdist_export(self) -> None:


### PR DESCRIPTION
Add a handler for sdist_exists to allow `dds pkg create` with an argument of `--if-exists=ignore` to behavior differently from `--if-exists=fail`.

At the same time, fix some typos around the pkg create command.

Fixes #92.
Fixes some of #89.