### PR TITLE
Replace mention of old "sdist" command with "pkg"

### DIFF
--- a/docs/guide/source-dists.rst
+++ b/docs/guide/source-dists.rst
@@ -16,7 +16,7 @@ Generating a Source Distribution
 ********************************
 
 Generating a source distribution from a project directory is done with the
-``sdist`` subcommand::
+``pkg`` subcommand::
 
 > bpt pkg create
 


### PR DESCRIPTION
alpha.6 renamed the `sdist` subcommand to `pkg`.