### PR TITLE
Abort sdist archive creation if target filename is a directory

### DIFF
--- a/src/bpt/sdist/dist.cpp
+++ b/src/bpt/sdist/dist.cpp
@@ -90,6 +90,10 @@ void bpt::create_sdist_targz(path_ref filepath, const sdist_params& params) {
             throw_user_error<errc::sdist_exists>("Destination path '{}' already exists",
                                                  filepath.string());
         }
+        if (fs::is_directory(filepath)) {
+            throw_user_error<errc::sdist_exists>("Destination path '{}' is a directory",
+                                                 filepath.string());
+        }
     }
 
     auto tempdir = temporary_dir::create();


### PR DESCRIPTION
See issue #125.

This change fixes the **`THIS IS A BPT BUG!`** notice if the target of `bpt pkg create` is an existing directory.

Instead `bpt` now refuses to replace the target (even though `--if-exists=replace` was given) because it is assumed the operation is unsafe. The user specified a directory where a filename was expected.

Fixes #125 