### PR TITLE
Actually create temporary directories on *nix

### DIFF
--- a/src/bpt/temp.nix.cpp
+++ b/src/bpt/temp.nix.cpp
@@ -1,13 +1,18 @@
 #include "./temp.hpp"
 
 #ifndef _WIN32
+
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
 using namespace bpt;
 
 temporary_dir temporary_dir::create_in(path_ref base) {
+    fs::create_directories(base);
+
     auto file = (base / "bpt-tmp-XXXXXX").string();
-
-    const char* tempdir_path = ::mktemp(file.data());
-
+    const char* tempdir_path = ::mkdtemp(file.data());
     if (tempdir_path == nullptr) {
         throw std::system_error(std::error_code(errno, std::system_category()),
                                 "Failed to create a temporary directory");
@@ -15,4 +20,5 @@ temporary_dir temporary_dir::create_in(path_ref base) {
     auto path = fs::path(tempdir_path);
     return std::make_shared<impl>(std::move(path));
 }
+
 #endif


### PR DESCRIPTION
`mktemp` doesn't actually create the directory and is [pretty broken on some platforms](https://man7.org/linux/man-pages/man3/mktemp.3.html#BUGS). `mkdtemp`, `mkstemp` and friends are here to fix this.