### PR TITLE
Implement repo import for prepackged CRS packages

### DIFF
--- a/src/bpt/crs/error.hpp
+++ b/src/bpt/crs/error.hpp
@@ -12,7 +12,7 @@ struct e_repo_open_path {
     std::filesystem::path value;
 };
 
-struct e_repo_importing_dir {
+struct e_repo_importing_path {
     std::filesystem::path value;
 };
 

--- a/src/bpt/crs/repo.hpp
+++ b/src/bpt/crs/repo.hpp
@@ -23,6 +23,7 @@ class repository {
         , _dirpath(dirpath) {}
 
     void _vacuum_and_compress() const;
+    package_info _import_dir(const std::filesystem::path& dirpath);
 
 public:
     static repository create(const std::filesystem::path& directory, std::string_view name);
@@ -31,6 +32,7 @@ public:
     std::filesystem::path subdir_of(const package_info&) const noexcept;
 
     auto        pkg_dir() const noexcept { return _dirpath / "pkg"; }
+    auto        tmp_dir() const noexcept { return _dirpath / "tmp"; }
     auto&       root() const noexcept { return _dirpath; }
     std::string name() const;
 


### PR DESCRIPTION
Right now, importing CRS packages created with `bpt pkg create` into a repository is kind of awkward, because you have to manually expand them first before running `bpt repo import`.
The description of `bpt repo import` already states *Import a directory **or package** into a CRS repository* and the header of `bpt::crs::repository` already contained a [method prototype for `import_targz()`](https://github.com/vector-of-bool/bpt/blob/f05f82c5be88eb2279cdd2f5772d033a221f5607/src/bpt/crs/repo.hpp#L37), making it obvious that the intention to provide "direct" imports was there already.

Notable changes:
- Implemented `bpt::crs::repository::import_targz()`. Note that `import_targz()` and `import_dir()` share most of the implementation.
- `bpt repo import` (`bpt::cli::cmd::<anon>::_import_file()`) checks if the provided path is a (potentially symlinked) regular file or a directory and then calls either `bpt::crs::repository::import_targz()` or `bpt::crs::repository::import_dir()`.
- Renamed `bpt::crs::e_repo_importing_dir` to `bpt::crs::e_repo_importing_path` and changed various occurences of the word `dir` to `path`.

The import algorithm for CRS packages is basically:
- extract the archive to a temporary location (`$repo/tmp/...`)
- do a "normal" import from that location

I experimented with a [different approach](https://github.com/maxtruxa/bpt/commit/bf43eae2d9293c754c0cb37f743fb354728dbaf7) for a bit, extracting just the `pkg.json` and storing the original archive in the repository. This has the downside (upside?) that packages containing arbitrary files can be stored in the repository. The current approach would discard any unsupported files during the import, because the archive is rebuilt from scratch.